### PR TITLE
fix matching of current dns domain name

### DIFF
--- a/wizard-run
+++ b/wizard-run
@@ -1,7 +1,7 @@
 #!/bin/vbash
 #
 # EdgeMAX Wizard "0xFF-BMK-Webstatus-LetsEncrypt" created 02/2017 by CPO/BMK for FunkFeuer.at
-# Version 20190910/bmk4.8
+# Version 20190923/bmk4.8
 # ^-- previous line is used frombmk-webstatus-package as version identification, dont remove "Version "
 # Shortform: 0xffwsle 0xFF-WSLE
 #

--- a/wizard-run
+++ b/wizard-run
@@ -5960,7 +5960,7 @@ esac
 
     #get current register from domain.csr
     if [ -f /config/letsencrypt/domain.csr ]; then
-        CURRENT=$(openssl req -in /config/letsencrypt/domain.csr -noout -text | grep Subject | grep CN= | awk -F'=' {'print $2'} | awk '{print tolower($0)}')
+        CURRENT=$(openssl req -in /config/letsencrypt/domain.csr -noout -text | grep -E 'Subject: CN.?=' | awk -F'=' {'print $2'} | awk '{print tolower($0)}')
         if [ ! "$CURRENT" ]; then 
             CURRENT=$(openssl req -in /config/letsencrypt/domain.csr -noout -text | grep -A 1 "X509v3 Subject Alternative Name" | tail -n 1 | sed -e 's/ //g' | sed -e 's/DNS://g' )
             CURRENT=$(echo $CURRENT | tr , "\n" | sort | tr "\n" , | awk '{gsub(".$","");print $1}' | awk '{print tolower($0)}')
@@ -6451,7 +6451,7 @@ zfvr/rq//s3XH7wmIhIAcgAA
             done
             LISTCOUNT=$(echo "$LIST" | wc -l)
 
-            CURRENT=$(openssl req -in /config/letsencrypt/domain.csr -noout -text | grep Subject | grep CN= | awk -F'=' {'print $2'} | awk '{print tolower($0)}')
+            CURRENT=$(openssl req -in /config/letsencrypt/domain.csr -noout -text | grep -E 'Subject: CN.?=' | awk -F'=' {'print $2'} | awk '{print tolower($0)}')
             if [ ! "$CURRENT" ]; then 
                 CURRENT=$(openssl req -in /config/letsencrypt/domain.csr -noout -text | grep -A 1 "X509v3 Subject Alternative Name" | tail -n 1 | sed -e 's/ //g' )
                 CURRENT=$(echo $CURRENT | tr , "\n" | sort | tr "\n" , | awk '{gsub(".$","");print $1}' | awk '{print tolower($0)}')

--- a/wizard.html
+++ b/wizard.html
@@ -2,16 +2,16 @@
 
 EdgeMAX Wizard "0xFF-BMK-Webstatus-LetsEncrypt" created 02/2017 by CPO/BMK for FunkFeuer.at
 Works on EdgeRouter and EdgeRouter X / X-SFP (system version 1.9.0+)
-versioninfo=201909100
+versioninfo=201909230
 ^-- use version identifier as number: YYYYMMDDX whereas X can be intraday-version
-autoupdate=201909100
+autoupdate=201909230
 ^-- set autoupdate the same version identifier to allow autoupdates
 
 
 -->
 <legend style="position:absolute;right:0px;padding:5px;">
     <center>EdgeMAX Wizard "0xFF-BMK-Webstatus-LetsEncrypt"<br>created 02/2017 by CPO/BMK for FunkFeuer.at<br>
-    Version 20190910/bmk4.8</center>
+    Version 20190923/bmk4.8</center>
 </legend>
 <div class="instructions">
     <h3>0xFF-BMK-Webstatus with Let's Encrypt setup</h3>


### PR DESCRIPTION
If there is a space after CN it is matched as well now, like
`Subject: CN = router.`

`Error checking current csr-file` was raised without that fix if only one domain name existed